### PR TITLE
Parse duration string using milliseconds to avoid fractions until the end

### DIFF
--- a/src/lib/duration.test.ts
+++ b/src/lib/duration.test.ts
@@ -6,13 +6,13 @@ import { parseDurationStr } from './duration.js';
 describe("timeStrToSeconds", () => {
     it("should parse various strings correctly", () => {
         const r1 = parseDurationStr("1.5s");
-        expect(r1).toEqual(1.5);
+        expect(r1).toEqual(1500);
 
         const r2 = parseDurationStr("5678ms");
-        expect(r2).toEqual(5.678);
+        expect(r2).toEqual(5678);
 
         const r3 = parseDurationStr("1d7h");
-        expect(r3).toEqual(111600);
+        expect(r3).toEqual(111600000);
     });
 
     it("should adjust output to output unit", () => {
@@ -25,12 +25,12 @@ describe("timeStrToSeconds", () => {
 
     it("should parse multiple sections", () => {
         const r1 = parseDurationStr("1s500ms");
-        expect(r1).toEqual(1.5);
+        expect(r1).toEqual(1500);
     });
 
     it("should parse parts without a unit as seconds", () => {
         const r3 = parseDurationStr("1d7h66");
-        expect(r3).toEqual(111666);
+        expect(r3).toEqual(111666000);
     });
 
     it("should throw for parts with invalid units", () => {

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,28 +1,28 @@
-const symbolToSecondMap = {
-    "": 1,
-    "ms": 0.001,
-    "s" : 1,
-    "m" : 60,
-    "h" : 60*60,
-    "d" : 60*60*24
+const UNIT_TO_MILLISECONDS = {
+    "": 1000,
+    "ms": 1,
+    "s" : 1000,
+    "m" : 1000*60,
+    "h" : 1000*60*60,
+    "d" : 1000*60*60*24
 };
 
-type UNITS = keyof typeof symbolToSecondMap;
+type UNITS = keyof typeof UNIT_TO_MILLISECONDS;
 
 function validateUnitType(unit: string): asserts unit is UNITS {
-    if (!(unit in symbolToSecondMap)) {
+    if (!(unit in UNIT_TO_MILLISECONDS)) {
         throw new Error(`unknown unit: '${unit}'`);
     }
 }
 
-function getUnitSeconds(unit: string) {
+function getUnitMilliseconds(unit: string) {
     validateUnitType(unit);
-    return symbolToSecondMap[unit];
+    return UNIT_TO_MILLISECONDS[unit];
 }
 
-export function parseDurationStr(timeStr: string | undefined, outputUnit = "s") {
+export function parseDurationStr(timeStr: string | undefined, outputUnit = "ms") {
     timeStr = timeStr || "";
-    const outputScale = getUnitSeconds(outputUnit);
+    const outputScale = getUnitMilliseconds(outputUnit);
 
     var total = 0;
 
@@ -40,7 +40,7 @@ export function parseDurationStr(timeStr: string | undefined, outputUnit = "s") 
             decPart += (+ char) / decPlace;
         } else if((+ char) >= 0 && (+ char) <= 9) {
             if(!parsingNum) {
-                const scale = getUnitSeconds(unit);
+                const scale = getUnitMilliseconds(unit);
 
                 total += (numPart * scale) + decPart;
 
@@ -63,7 +63,7 @@ export function parseDurationStr(timeStr: string | undefined, outputUnit = "s") 
 
     }
 
-    const scale = getUnitSeconds(unit);
+    const scale = getUnitMilliseconds(unit);
 
     total += (numPart * scale) + decPart;
 


### PR DESCRIPTION
The main code only parses the duration string to check if it's 0, or to convert it to milliseconds, so this change avoids all non-integers during the calculation.